### PR TITLE
example-clients: fix inverted arguments

### DIFF
--- a/example-clients/afi-client/AfiClient.cpp
+++ b/example-clients/afi-client/AfiClient.cpp
@@ -964,8 +964,8 @@ AfiClient::handleCliCommand(std::string const & command_str)
         std::cout << "Adding ether encap node" << std::endl;
         AftNodeToken nextToken = std::strtoull(command_args.at(4).c_str(),NULL,0);;
 
-        AftNodeToken nhEncapToken = addEtherEncapNode(command_args.at(0), 
-                                                      command_args.at(1), 
+        AftNodeToken nhEncapToken = addEtherEncapNode(command_args.at(1), 
+                                                      command_args.at(0), 
                                                       command_args.at(2), 
                                                       command_args.at(3), 
                                                       nextToken);


### PR DESCRIPTION
The first argument of the addEtherEncapNode() function is the destination
MAC address, whereas the first argument of the "add-ether-encap"
interactive command in the source MAC address. Invert the order of the
arguments to fix the problem.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>